### PR TITLE
ckpt: add open/close for reading checkpoint

### DIFF
--- a/deepspeed/runtime/checkpoint_engine/checkpoint_engine.py
+++ b/deepspeed/runtime/checkpoint_engine/checkpoint_engine.py
@@ -9,7 +9,7 @@ class CheckpointEngine(object):
     def __init__(self, config_params=None):
         pass
 
-    def create(self, tag):
+    def create(self, save_dir, tag):
         # create checkpoint on give tag for save/load.
         pass
 
@@ -19,9 +19,15 @@ class CheckpointEngine(object):
     def save(self, state_dict, path: str):
         pass
 
+    def commit(self, tag):
+        # to tell checkpoint services if all files are readys.
+        pass
+
+    def open(self, load_dir=None, tag=None):
+        pass
+
     def load(self, path: str, map_location=None):
         pass
 
-    def commit(self, tag):
-        # to tell checkpoint services if all files are readys.
+    def close(self, tag):
         pass

--- a/deepspeed/runtime/checkpoint_engine/checkpoint_engine.py
+++ b/deepspeed/runtime/checkpoint_engine/checkpoint_engine.py
@@ -1,5 +1,7 @@
 '''Copyright The Microsoft DeepSpeed Team'''
 
+import os
+
 
 class CheckpointEngine(object):
 
@@ -10,6 +12,9 @@ class CheckpointEngine(object):
     def create(self, tag):
         # create checkpoint on give tag for save/load.
         pass
+
+    def makedirs(self, path, exist_ok=False):
+        os.makedirs(path, exist_ok=exist_ok)
 
     def save(self, state_dict, path: str):
         pass

--- a/deepspeed/runtime/checkpoint_engine/nebula_checkpoint_engine.py
+++ b/deepspeed/runtime/checkpoint_engine/nebula_checkpoint_engine.py
@@ -32,7 +32,7 @@ class NebulaCheckpointEngine(CheckpointEngine):
         }
         torch_nebula.init(**nebula_config_params)
 
-    def create(self, tag):
+    def create(self, save_dir, tag):
         log_dist(f"[Nebula] Start Checkpoint for tag:{tag}", ranks=[0])
         # -2 means: customer needs to  explicitly tell nebula
         # current checkpoint is complete by commit methond.
@@ -49,21 +49,22 @@ class NebulaCheckpointEngine(CheckpointEngine):
         logger.info(f"[Nebula] Saved {partititon_name} under tag {tag}.")
         return None
 
-    def load(self, path: str, map_location=None):
-        tag = _get_tag_from_path(path)
+    def commit(self, tag):
+        # nebula commit will be call when all files under give tag are ready to be persisted in the async way.
+        logger.info(
+            f"[Nebula] all files for {tag} are saved in tier1. It is ready to start persisting"
+        )
+        commit_rls = self.checkpoint.commit()
+        if not commit_rls:
+            logger.error(
+                f"[Nebula] failed to commit the checkpoint, please check the log.")
+            return False
+        return commit_rls
+
+    def open(self, load_dir=None, tag=None):
         first_load_flag = self.tag_flag is None or self.tag_flag == tag
         if not self.enable_nebula_load and first_load_flag:
-            self.tag_flag = tag
-            logger.info(
-                f"[Nebula] Disable nebula load. Loading checkpoint from {path} ...")
-            partition = torch.load(path, map_location=map_location)
-            logger.info(f"[Nebula] Disable nebula load. Loaded checkpoint from {path} .")
-            return partition
-
-        partititon_name = os.path.basename(path)
-        logger.info(
-            f"[Nebula] Loading {path} under tag {tag} from nebula path {self.nebula_load_path}..."
-        )
+            return tag
 
         checkpoint = None
         if tag in (None, 'latest', 'latest_universal'):
@@ -95,21 +96,33 @@ class NebulaCheckpointEngine(CheckpointEngine):
                     f"Unable to find valid checkpoint from Nebula under tag:{tag}.")
                 return None
 
-        tag = checkpoint.tag
+        self.checkpoint = checkpoint
         self.tag_flag = -1
-        partition = checkpoint.load(partititon_name, map_location=map_location)
+
+        tag = checkpoint.tag
+        return tag
+
+    def load(self, path: str, map_location=None):
+        if self.checkpoint is None:
+            tag = _get_tag_from_path(path)
+            self.tag_flag = tag
+            logger.info(
+                f"[Nebula] Disable nebula load. Loading checkpoint from {path} ...")
+            partition = torch.load(path, map_location=map_location)
+            logger.info(f"[Nebula] Disable nebula load. Loaded checkpoint from {path} .")
+            return partition
+
+        tag = self.checkpoint.tag
+
+        partititon_name = os.path.basename(path)
+        logger.info(
+            f"[Nebula] Loading {path} under tag {tag} from nebula path {self.nebula_load_path}..."
+        )
+
+        partition = self.checkpoint.load(partititon_name, map_location=map_location)
         logger.info(
             f"[Nebula] Loaded {path} under tag {tag} from {self.nebula_load_path}.")
         return partition
 
-    def commit(self, tag):
-        # nebula commit will be call when all files under give tag are ready to be persisted in the async way.
-        logger.info(
-            f"[Nebula] all files for {tag} are saved in tier1. It is ready to start persisting"
-        )
-        commit_rls = self.checkpoint.commit()
-        if not commit_rls:
-            logger.error(
-                f"[Nebula] failed to commit the checkpoint, please check the log.")
-            return False
-        return commit_rls
+    def close(self, tag):
+        self.checkpoint = None

--- a/deepspeed/runtime/checkpoint_engine/torch_checkpoint_engine.py
+++ b/deepspeed/runtime/checkpoint_engine/torch_checkpoint_engine.py
@@ -1,5 +1,7 @@
 '''Copyright The Microsoft DeepSpeed Team'''
 
+import os
+
 import torch
 from deepspeed.utils import logger, log_dist
 from deepspeed.runtime.checkpoint_engine.checkpoint_engine import \
@@ -7,10 +9,14 @@ from deepspeed.runtime.checkpoint_engine.checkpoint_engine import \
 
 
 class TorchCheckpointEngine(CheckpointEngine):
-    def __init__(self, config_params=None):
+    def __init__(self, config_params=None, rank=0):
         super().__init__(config_params)
+        self.rank = rank
+        self.save_latest = True
+        self.save_dir = None
 
-    def create(self, tag):
+    def create(self, save_dir, tag):
+        self.save_dir = save_dir
         log_dist(f"[Torch] Checkpoint {tag} is begin to save!", ranks=[0])
 
     def save(self, state_dict, path: str):
@@ -19,12 +25,30 @@ class TorchCheckpointEngine(CheckpointEngine):
         logger.info(f"[Torch] Saved {path}.")
         return None
 
+    def commit(self, tag):
+        # record tag of most recent checkpoint in 'latest' file
+        if self.save_latest and self.rank == 0:
+            with open(os.path.join(self.save_dir, 'latest'), 'w') as fd:
+                fd.write(tag)
+
+        self.save_dir = None
+        logger.info(f"[Torch] Checkpoint {tag} is ready now!")
+        return True
+
+    def open(self, load_dir=None, tag=None):
+        # read tag from latest file if not given an actual name
+        if tag in ['latest', 'latest_universal']:
+            latest_path = os.path.join(load_dir, tag)
+            if os.path.isfile(latest_path):
+                with open(latest_path, "r") as fd:
+                    tag = fd.read().strip()
+                    return tag
+            else:
+                return None
+        return tag
+
     def load(self, path: str, map_location=None):
         logger.info(f"[Torch] Loading checkpoint from {path}...")
         partition = torch.load(path, map_location=map_location)
         logger.info(f"[Torch] Loaded checkpoint from {path}.")
         return partition
-
-    def commit(self, tag):
-        logger.info(f"[Torch] Checkpoint {tag} is ready now!")
-        return True

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -916,7 +916,13 @@ class DeepSpeedEngine(Module):
         log_dist(f'DeepSpeed LR Scheduler = {self.lr_scheduler}', ranks=[0])
 
     def _configure_checkpointing(self, dist_init_required):
-        self.checkpoint_engine = TorchCheckpointEngine()
+        dp_rank = self.global_rank
+        if self.mpu:
+            dp_rank = self.mpu.get_data_parallel_rank()
+
+        rank = self.local_rank if self.use_node_local_storage() else dp_rank
+
+        self.checkpoint_engine = TorchCheckpointEngine(rank=rank)
 
         if self._config is not None and self._config.nebula_config.enabled:
             try:
@@ -928,13 +934,7 @@ class DeepSpeedEngine(Module):
                 logger.error(
                     f"No torch_nebula was found! Will fall back to torch.save. Details: {err}"
                 )
-                self.checkpoint_engine = TorchCheckpointEngine()
-
-        dp_rank = self.global_rank
-        if self.mpu:
-            dp_rank = self.mpu.get_data_parallel_rank()
-
-        rank = self.local_rank if self.use_node_local_storage() else dp_rank
+                self.checkpoint_engine = TorchCheckpointEngine(rank=rank)
 
         # only the first data parallel process needs to store the model checkpoint
         # if you want to use node local storage this must be done by rank 0 on each
@@ -2748,23 +2748,20 @@ class DeepSpeedEngine(Module):
         """
 
         if tag is None:
-            latest_tag = "latest_universal" if self.load_universal_checkpoint(
-            ) else "latest"
-            latest_path = os.path.join(load_dir, latest_tag)
-            if os.path.isfile(latest_path):
-                with open(latest_path, "r") as fd:
-                    tag = fd.read().strip()
+            tag = "latest_universal" if self.load_universal_checkpoint() else "latest"
+
+        tag = self.checkpoint_engine.open(load_dir, tag)
+
+        if tag is None:
+            if self.load_universal_checkpoint():
+                raise ValueError(
+                    f'Invalid for universal checkpoint: {load_dir} does not exist')
             else:
-                if self.load_universal_checkpoint():
-                    raise ValueError(
-                        f'Invalid for universal checkpoint: {latest_path} does not exist'
-                    )
-                else:
-                    logger.warning(
-                        f"Unable to find latest file at {latest_path}, if trying to load latest "
-                        "checkpoint please ensure this file exists or pass an explicit checkpoint tag when loading a checkpoint."
-                    )
-                    return None, None
+                logger.warning(
+                    f"Unable to find latest file at {load_dir}, if trying to load latest "
+                    "checkpoint please ensure this file exists or pass an explicit checkpoint tag when loading a checkpoint."
+                )
+                return None, None
 
         if self.zero_optimization_partition_weights():
             # Prepare for checkpoint load by ensuring all parameters are partitioned
@@ -2789,6 +2786,8 @@ class DeepSpeedEngine(Module):
 
         if self.zero_optimization_partition_weights():
             self.optimizer.checkpoint_event_epilogue()
+
+        self.checkpoint_engine.close(tag)
 
         return load_path, client_states
 
@@ -3090,6 +3089,8 @@ class DeepSpeedEngine(Module):
         process with rank 0.
 
         """
+        # TODO: move save_latest to checkpoint config option for TorchCheckpointEngine?
+
         if self.zero_optimization_partition_weights():
             # Prepare for checkpoint save by ensuring all parameters are partitioned
             self.optimizer.checkpoint_event_prologue()
@@ -3108,7 +3109,7 @@ class DeepSpeedEngine(Module):
 
         # Ensure tag is a string
         tag = str(tag)
-        self.checkpoint_engine.create(tag)
+        self.checkpoint_engine.create(save_dir, tag)
 
         # Ensure checkpoint tag is consistent across ranks
         self._checkpoint_tag_validation(tag)
@@ -3135,9 +3136,6 @@ class DeepSpeedEngine(Module):
 
         # Save latest checkpoint tag
         self.checkpoint_engine.commit(tag)
-        if save_latest and rank == 0:
-            with open(os.path.join(save_dir, 'latest'), 'w') as fd:
-                fd.write(tag)
 
         dist.barrier()
 

--- a/deepspeed/runtime/engine.py
+++ b/deepspeed/runtime/engine.py
@@ -79,7 +79,7 @@ from deepspeed.runtime.data_pipeline.data_routing.basic_layer import RandomLayer
 from deepspeed.runtime.checkpoint_engine.torch_checkpoint_engine import TorchCheckpointEngine
 
 from .pipe.module import PipelineModule
-from .utils import ensure_directory_exists, get_ma_status
+from .utils import get_ma_status
 from ..ops.adam import FusedAdam
 from ..moe.sharded_moe import TopKGate, MOELayer
 from ..moe.layer import MoE
@@ -3100,7 +3100,7 @@ class DeepSpeedEngine(Module):
         # There seems to be issue creating them in parallel
 
         # Ensure save_dir directory exists
-        os.makedirs(save_dir, exist_ok=True)
+        self.checkpoint_engine.makedirs(save_dir, exist_ok=True)
         dist.barrier()
 
         if tag is None:
@@ -3278,7 +3278,8 @@ class DeepSpeedEngine(Module):
                          if zero_checkpoint else self._get_ckpt_name)
         try:
             checkpoint_name = name_function(save_dir, tag)
-            ensure_directory_exists(checkpoint_name)
+            path = os.path.dirname(checkpoint_name)
+            self.checkpoint_engine.makedirs(path, exist_ok=True)
         except:
             logger.error(f"Failed saving model checkpoint to {save_dir} with tag {tag}")
             return False
@@ -3528,7 +3529,7 @@ class DeepSpeedEngine(Module):
             state_dict = self.module.state_dict()
 
         if dist.get_rank() == 0:
-            os.makedirs(save_dir, exist_ok=True)
+            self.checkpoint_engine.makedirs(save_dir, exist_ok=True)
             logger.info(f"Saving model weights to {path}")
             self.checkpoint_engine.save(state_dict, path)
 

--- a/deepspeed/runtime/pipe/module.py
+++ b/deepspeed/runtime/pipe/module.py
@@ -587,7 +587,7 @@ class PipelineModule(nn.Module):
             start, end = 0, num_layers
         layer_list = self.forward_funcs[start:end]
 
-        os.makedirs(save_dir, exist_ok=True)
+        checkpoint_engine.makedirs(save_dir, exist_ok=True)
         for idx, layer in enumerate(layer_list):
             model_ckpt_path = self.ckpt_layer_path(save_dir, start + idx)
             if not hasattr(layer, 'state_dict'):

--- a/deepspeed/runtime/pipe/schedule.py
+++ b/deepspeed/runtime/pipe/schedule.py
@@ -206,19 +206,19 @@ class TrainSchedule(PipeSchedule):
 
             # Exchange activations
             if is_forward:
-                if self._valid_micro_batch(micro_batch_id) and self._valid_stage(
-                        self.prev_stage):
-                    cmds.append(RecvActivation(curr_buffer))
                 if self._valid_micro_batch(prev_micro_batch_id) and self._valid_stage(
                         self.prev_stage):
                     cmds.append(SendGrad(prev_buffer))
+                if self._valid_micro_batch(micro_batch_id) and self._valid_stage(
+                        self.prev_stage):
+                    cmds.append(RecvActivation(curr_buffer))
             else:
-                if self._valid_micro_batch(prev_micro_batch_id) and self._valid_stage(
-                        self.next_stage):
-                    cmds.append(SendActivation(prev_buffer))
                 if self._valid_micro_batch(micro_batch_id) and self._valid_stage(
                         self.next_stage):
                     cmds.append(RecvGrad(curr_buffer))
+                if self._valid_micro_batch(prev_micro_batch_id) and self._valid_stage(
+                        self.next_stage):
+                    cmds.append(SendActivation(prev_buffer))
 
             # First/last stage loads
             if self.stage_id == 0 or self.stage_id == self.stages - 1:
@@ -243,9 +243,14 @@ class TrainSchedule(PipeSchedule):
             yield cmds
 
     def num_pipe_buffers(self):
-        """As many buffers as the distance from this stage to the last stage.
+        """Return the number of pipeline buffers required for this stage.
+
+        This is equivalent to the maximum number of in-flight forward passes,
+        since we need to remember the activations of forward passes in order
+        to run backpropagation. For synchronous 1F1B, this is equivalent to
+        the index difference between this stage and the last stage.
         """
-        buffers = min(self.stages - self.stage_id + 1, self.micro_batches)
+        buffers = min(self.stages - self.stage_id, self.micro_batches)
         return max(2, buffers)
 
     def _step_to_micro_batch(self, step_id):


### PR DESCRIPTION
For consideration, this adds ``open()`` and ``close()`` calls to the ``CheckpointEngine`` to serve as start and end markers during a restart.  Similar to how ``create()`` and ``commit()`` define the start and end markers when writing a checkpoint, these new calls are useful for checkpoint engines while reading a checkpoint.

The ``open()`` function can be used by the checkpoint engine to find and prepare a checkpoint for reading.  The caller may specify a directory in ``load_dir`` and a checkpoint name in ``tag``.  If ``tag == None`` or ``"latest"``, the checkpoint engine loads the most recent checkpoint that it can find.  Otherwise, the checkpoint engine attempts to load the checkpoint name specified by ``tag``.  ``open()`` returns the ``tag`` value of the checkpoint that it actually loaded, or ``None`` if it fails to find a checkpoint.

The ``close()`` call can be used to free any resources that were allocated by the checkpoint engine during ``open()``.

All ``load()`` calls that read checkpoint files should be placed between ``open()`` and ``close()`` bookends.

Implementation details:
- This moves the processing for the ``latest`` file to ``TorchCheckpointEngine``.  It is written during ``commit()`` and read during ``open()``.  For now, ``save_latest`` is a member variable of the class that is hard coded to be ``True``.  To make this dynamic, this could either be a config parameter or an option passed to ``create()``.
- I took an educated guess at updating Nebula to use ``open()`` and ``close()``, but it's not possible for me to test the code.  The main change is that the search logic that locates the checkpoint has been moved from ``load()`` to ``open()``.
- As an extension, the ``load_dir`` parameter that is passed to ``open()`` could be made optional, in which case, one could use the current working directory, or ``load_dir`` could be passed as a parameter to the checkpoint engine constructor.  Similarly for ``save_dir``.  I'm guessing that for most cases, those directory paths do not change during the run.
- The checkpoint engine README still needs to be updated to document the interface.